### PR TITLE
Fix lora issue

### DIFF
--- a/gritlm/training/run.py
+++ b/gritlm/training/run.py
@@ -273,7 +273,6 @@ def main():
         # https://github.com/texttron/tevatron/blob/2e5d00ee21d5a7db0bd2ea1463c9150a572106d4/examples/repllama/repllama.py#L81
         # https://github.com/allenai/open-instruct/blob/9ebcb582cfc243a6dab75b4302fa432784db26c2/open_instruct/finetune.py#L478
         peft_config = LoraConfig(
-            task_type=TaskType.CAUSAL_LM, 
             inference_mode=False, 
             r=16, 
             lora_alpha=64,


### PR DESCRIPTION
I removed the task_type parameter from LoraConfig instantiation object. Without any specific task, Loraconfig sets the value to None.

With task_type=TaskType.CAUSAL_LM launch TypeError: GemmaModel.forward() got an unexpected keyword argument 'labels'

It also works with TaskType.FEATURE_EXTRACTION. 

I tested with peft v0.10.0.

I tested with the following configuration:

torchrun --nproc_per_node 1 -m training.run --output_dir test_path --model_name_or_path openaccess-ai-collective/tiny-mistral --train_data training/toy_data/toy_data_embedding.jsonl --learning_rate 1e-5 --num_train_epochs 5 --per_device_train_batch_size 1 --dataloader_drop_last True --normalized True --temperature 0.02 --query_max_len 16 --passage_max_len 64 --train_group_size 2 --mode embedding --attn cccc **--lora True**

qlora also works because the problem was in LoraConfig.