### PR TITLE
Update eval_mteb.py

### DIFF
--- a/evaluation/eval_mteb.py
+++ b/evaluation/eval_mteb.py
@@ -1159,7 +1159,7 @@ if __name__ == '__main__':
         kwargs["tasks"] = args.task_names.split(",")
     elif args.task_types:
         kwargs["task_types"] = args.task_types.split(",")
-    tasks = [(t.metadata.name, t.metadata.type) for t in MTEB(**kwargs).tasks
+    tasks = [(t.metadata.name, t.metadata.type) for t in MTEB(**kwargs).tasks]
     
     if args.max_length is not None:
         model.encode = partial(model.encode, max_length=args.max_length)


### PR DESCRIPTION
added the **close square bracket** on **line 1162**. which was throwing the error given below:  
```
gritlm/evaluation/eval_mteb.py", line 1162
    tasks = [(t.metadata.name, t.metadata.type) for t in MTEB(**kwargs).tasks
            ^
SyntaxError: '[' was never closed
```
**Now I fixed this.**
and this occurs while running the command:
- ```python evaluation/eval_mteb.py --model_name_or_path GritLM/GritLM-7B --task_types Classification,Clustering,PairClassification,Reranking,Retrieval,STS,Summarization --batch_size 32```